### PR TITLE
Feature/5595 prevent vacuum mess

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:2-slim
 
+RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" > /etc/apt/sources.list.d/stretch-backports.list
 RUN apt-get update && mkdir -p /usr/share/man/man1 /usr/share/man/man7
 RUN apt-get install -y libpq-dev postgresql-client gcc
+RUN apt install -y -t stretch-backports redis-tools
 
 WORKDIR /usr/src/app
 COPY src/ /usr/src/app/

--- a/src/bin/entrypoint.sh
+++ b/src/bin/entrypoint.sh
@@ -4,9 +4,10 @@ set -e
 
 PROJECT=${1:-}
 
-if [ "${PROJECT}" == "analyze-vacuum" ]; then bin/run-analyze-vacuum-utility.sh
+if [ "${PROJECT}" == "fa-analyze-vacuum" ]; then bin/run-fa-vacuum-guard.sh
+elif [ "${PROJECT}" == "analyze-vacuum" ]; then bin/run-analyze-vacuum-utility.sh
 elif [ "${PROJECT}" == "column-encoding" ]; then bin/run-column-encoding-utility.sh
 elif [ "${PROJECT}" == "unload-copy" ]; then bin/run-unload-copy-utility.sh
 elif [ "${PROJECT}" == "user-last-login" ]; then bin/run-user-last-login.sh
-else echo "Unhandled arg for project to run. Please select from either 'analyze-vacuum', 'column-encoding' or 'unload-copy'"
+else echo "Unhandled arg for project to run. Please select from either 'fa-analyze-vacuum', 'analyze-vacuum', 'column-encoding' or 'unload-copy'"
 fi

--- a/src/bin/run-fa-vacuum-guard.sh
+++ b/src/bin/run-fa-vacuum-guard.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Running FollowAnalytics analyze-vacuum GUARD utility"
+
+# Required
+REDIS_URL=${REDIS_URL:-}
+
+REDIS="redis-cli"
+LOCK_KEY="locking:tasks:solo:RedAggregateDevicesAndUsersJob"
+BREAK_ON="1"
+
+REDIS_CMD="$REDIS -u $REDIS_URL"
+RELEASE_CMD="echo \"DEL $LOCK_KEY\" | $REDIS_CMD"
+
+tryLock () {
+  local redis_order="SETNX $LOCK_KEY `date -u +"%Y-%m-%dT%H:%M:%SZ"` EX 1200"
+  local cmd="echo \"$redis_order\" | $REDIS_CMD"
+  local result=$(eval $cmd)
+  echo $result
+}
+
+echo "Waiting for lock on $LOCK_KEY from redis $REDIS_URL"
+for (( ; ; ))
+do
+  TRYLOCK="$(tryLock)"
+  echo $TRYLOCK
+  if [ "$TRYLOCK" == "$BREAK_ON" ]
+  then
+    echo "Lock acquired"
+    bin/run-analyze-vacuum-utility.sh
+    echo "Vacuum done. Release lock"
+    $(eval $RELEASE_CMD)
+    break
+  fi
+  echo "Waiting"
+  sleep 2
+done

--- a/src/bin/run-fa-vacuum-guard.sh
+++ b/src/bin/run-fa-vacuum-guard.sh
@@ -9,13 +9,13 @@ REDIS_URL=${REDIS_URL:-}
 
 REDIS="redis-cli"
 LOCK_KEY="locking:tasks:solo:RedAggregateDevicesAndUsersJob"
-BREAK_ON="1"
+BREAK_ON="OK"
 
 REDIS_CMD="$REDIS -u $REDIS_URL"
 RELEASE_CMD="echo \"DEL $LOCK_KEY\" | $REDIS_CMD"
 
 tryLock () {
-  local redis_order="SETNX $LOCK_KEY `date -u +"%Y-%m-%dT%H:%M:%SZ"` EX 1200"
+  local redis_order="SET $LOCK_KEY `date -u +"%Y-%m-%dT%H:%M:%SZ"` EX 1200 NX"
   local cmd="echo \"$redis_order\" | $REDIS_CMD"
   local result=$(eval $cmd)
   echo $result


### PR DESCRIPTION
Reference: followanalytics/fa-issues#5595

Wrap the original script rather than alter it, so a future upstream merge would be easier.

Before running the aws vacuum script, it tries to acquire the aggregation lock from our Redis then set it and run the script.
Once finished, clear the lock.